### PR TITLE
A JSON response must include the charset

### DIFF
--- a/backend/app/view/BDecotexView.php
+++ b/backend/app/view/BDecotexView.php
@@ -51,7 +51,7 @@ class BDecotexView {
     
     protected function returnSuccess($res = NULL) {
         header($_SERVER['SERVER_PROTOCOL'] . ' 200 Success', true, 200);
-        header("Content-Type: application/json");
+        header('Content-Type: application/json; Charset="UTF-8"');
         if ($res != NULL){
             echo json_encode($res);
         }


### PR DESCRIPTION
I found a web explaining that a JSON response must include the charset
http://stackoverflow.com/questions/7284535/json-with-special-characters-like-é